### PR TITLE
Highlight zero-width characters

### DIFF
--- a/src/inject/inject.css
+++ b/src/inject/inject.css
@@ -17,3 +17,8 @@
   position: absolute;
   right: 0;
 }
+
+.zero-width-character:after {
+  color: red;
+  content: '\25CF';
+}

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -2,6 +2,19 @@
   let elementsWithZWCC = [];
 
   /**
+   * Highlight zero-width character in DOM element
+   *
+   * @param  {dom node} element   A DOM node.
+   */
+  const highlightCharacters = function(element) {
+    const zeroWidthCharacters = String.fromCodePoint(...zeroWidthCharacterCodes);
+    const regExp = new RegExp(`([${zeroWidthCharacters}])`, 'g')
+
+    element.innerHTML = element.innerHTML
+      .replace(regExp, '$1<span class="zero-width-character"></span>');
+  };
+
+  /**
   * Checks DOM element for zero-width character.
   *
   * @param {dom node} element   A DOM node.
@@ -22,10 +35,6 @@
         elementsWithZWCC.push(element)
       }
     });
-
-    elementsWithZWCC.forEach(function( element ) {
-      element.classList.add('zero-width-characters');
-    })
   }
 
   /**
@@ -59,7 +68,13 @@
   */
   const checkPage = function() {
     const allElements = document.getElementsByTagName('*');
-    [...allElements].forEach( checkElement );
+
+    [...allElements].forEach(checkElement);
+
+    elementsWithZWCC.forEach(function( element ) {
+      element.classList.add('zero-width-characters');
+      highlightCharacters(element);
+    });
   }
 
   chrome.extension.sendMessage({}, function(response) {


### PR DESCRIPTION
# Solution #3 

Just simple replace in the `HTML` source from the element with a `span` element for every match with zero-widht character and finally added some style to the class `zero-width-character`.

![screenshot_743](https://user-images.githubusercontent.com/34191406/38533924-cef84f80-3c51-11e8-87e8-749ac5f0e8a9.png)

# Refactor

I moved the line that set the class `zero-width-characters` to `checkPage` because while I test the `highlightCharacters` function I noticed that this line is executed multiples times with the code in `highlightCharacters`, but why ? Because for every element from `document.getElementsByTagName('*')` the `elementsWithZWCC.forEach` is executed with other lines that exists.

# Particularity in the process

When I replace totally some character with the `span` element the text without sanitize from copy (`CTRL + C`) not contain this character, because of this I capture de character and add near from `span`, maybe someone need the original text and prefer use the `Sanitize and copy` option from the context menu to get the sanitized text ?